### PR TITLE
fix: vercel deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ dist/
 # generated types
 .astro/
 
+# vercel build output
+.vercel/
+
 # dependencies
 node_modules/
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,12 +1,13 @@
 import { defineConfig } from 'astro/config';
 import vercel from '@astrojs/vercel';
+import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
   adapter: vercel(),
   vite: {
     resolve: {
       alias: {
-        '@db': '/src/db',
+        '@db': fileURLToPath(new URL('./src/db', import.meta.url)),
       },
     },
   },


### PR DESCRIPTION
## Summary
- resolve alias for DB using absolute path for Vercel builds
- ignore Vercel build output folder

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c1e79643f483318dfdfb7d46a6785e